### PR TITLE
image select

### DIFF
--- a/frontend/app/src/main/java/com/project/spire/ui/MainActivity.kt
+++ b/frontend/app/src/main/java/com/project/spire/ui/MainActivity.kt
@@ -1,8 +1,11 @@
 package com.project.spire.ui
 
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toolbar
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.findNavController
@@ -11,6 +14,8 @@ import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import com.example.spire.R
 import com.example.spire.databinding.ActivityMainBinding
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.project.spire.ui.create.image.ImageEditActivity
 
 class MainActivity : AppCompatActivity() {
 
@@ -45,5 +50,24 @@ class MainActivity : AppCompatActivity() {
 
         setupActionBarWithNavController(navController, appBarConfiguration)
         navView.setupWithNavController(navController)
+
+        // select image via PhotoPicker
+        val createPostBtn: FloatingActionButton = binding.fab
+        val pickMedia = registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+            if (uri != null) {
+                Log.d("PhotoPicker", "Selected URI: $uri")
+                val intent = Intent(this, ImageEditActivity::class.java)
+                intent.putExtra("imageUri", uri.toString())
+                startActivity(intent)
+                //finish() // TODO: should not finish main?
+            } else {
+                Log.d("PhotoPicker", "No media selected")
+            }
+        }
+        createPostBtn.setOnClickListener {
+            pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+        }
     }
+
+
 }

--- a/frontend/app/src/main/java/com/project/spire/ui/create/image/ImageCreateViewModel.kt
+++ b/frontend/app/src/main/java/com/project/spire/ui/create/image/ImageCreateViewModel.kt
@@ -1,6 +1,10 @@
 package com.project.spire.ui.create.image
 
+import android.graphics.Path
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffXfermode
 import android.net.Uri
+import android.view.MotionEvent
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -14,5 +18,120 @@ class ImageCreateViewModel: ViewModel() {
         _originImageUri.value = uri
     }
 
+    private val STROKE_PEN = 20f
+    private val STROKE_ERASER = 50f
+    private val MODE_CLEAR = PorterDuffXfermode(PorterDuff.Mode.CLEAR) // clears when overlapped
 
+    private var _paths = LinkedHashMap<Path, PaintOptions>()
+    val paths: LinkedHashMap<Path, PaintOptions>
+        get() = _paths
+    private var _paintOptions = PaintOptions(STROKE_PEN, null)
+    val paintOptions: PaintOptions
+        get() = _paintOptions
+
+    private var _currentX = 0f
+    private var _currentY = 0f
+    private var _startX = 0f
+    private var _startY = 0f
+
+    private var _isEraseMode = MutableLiveData<Boolean>(false)
+    val isEraseMode: LiveData<Boolean>
+        get() = _isEraseMode
+    private var _isPenMode = MutableLiveData<Boolean>(true)
+    val isPenMode: LiveData<Boolean>
+        get() = _isPenMode
+
+    private var _isDrawing = MutableLiveData<Boolean>(false)
+    val isDrawing: LiveData<Boolean>
+        get() = _isDrawing
+
+    private var _mPath: Path = Path()
+    val mPath: Path
+        get() = _mPath
+
+    // mPath를 LiveData로 만들고 mPath를 observe하는 것이 맞겠으나, 이 경우 화면 표시에 delay가 발생하여
+    // 대신 boolean type의 isDrawing을 observe
+    // invalidate()를 호출하여 화면을 다시 그려야 하는 순간마다 isDrawing의 값을 잠시 바꾸는 것으로
+    // 화면을 실시간으로 다시 그리도록 구현
+
+    fun clearCanvas() {
+        _mPath.reset()
+        _paths = LinkedHashMap()
+        _isEraseMode.postValue(false)
+        _isPenMode.postValue(false)
+        _isDrawing.postValue(true)
+        _isDrawing.postValue(false)
+    }
+
+    fun changeEraseMode() {
+        if (!_isEraseMode.value!!) {
+            _isEraseMode.postValue(true)
+            _isPenMode.postValue(false)
+            _paintOptions.strokeWidth = STROKE_ERASER
+            _paintOptions.xfermode = MODE_CLEAR
+        }
+        else {
+            _isEraseMode.postValue(false)
+        }
+    }
+
+    fun changePenMode() {
+        if (!_isPenMode.value!!) {
+            _isEraseMode.postValue(false)
+            _isPenMode.postValue(true)
+            _paintOptions.strokeWidth = STROKE_PEN
+            _paintOptions.xfermode = null
+        }
+        else {
+            _isPenMode.postValue(false)
+        }
+    }
+
+    fun processCanvasMotionEvent(event: MotionEvent): Boolean {
+        if (!_isPenMode.value!! and !_isEraseMode.value!!) return true;
+        // don't need to track path is pen and eraser are both disabled
+
+        val y = event.y
+        val x = event.x
+        if (event.pointerCount == 1) { // don't track on multi-touch
+            when(event.action) {
+                MotionEvent.ACTION_DOWN -> {
+                    _startX = x
+                    _startY = y
+
+                    _mPath.reset()
+                    _mPath.moveTo(x, y)
+                    _currentX = x
+                    _currentY = y
+
+                    _isDrawing.postValue(true)
+                    _isDrawing.postValue(false)
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    _mPath.quadTo(_currentX, _currentY, (x + _currentX) / 2, (y + _currentY) / 2)
+                    _currentX = x
+                    _currentY = y
+
+                    _isDrawing.postValue(true)
+                    _isDrawing.postValue(false)
+                }
+                MotionEvent.ACTION_UP -> {
+                    _mPath.lineTo(_currentX, _currentY)
+
+                    // draw a dot on click
+                    if (_startX == _currentX && _startY == _currentY) {
+                        _mPath.lineTo(_currentX, _currentY + 2)
+                        _mPath.lineTo(_currentX + 1, _currentY + 2)
+                        _mPath.lineTo(_currentX + 1, _currentY)
+                    }
+                    _paths[_mPath] = _paintOptions
+                    _mPath = Path()
+                    _paintOptions = PaintOptions(_paintOptions.strokeWidth, _paintOptions.xfermode)
+                    _isDrawing.postValue(true)
+                    _isDrawing.postValue(false)
+                }
+            }
+        }
+        return true
+    }
 }

--- a/frontend/app/src/main/java/com/project/spire/ui/create/image/ImageCreateViewModel.kt
+++ b/frontend/app/src/main/java/com/project/spire/ui/create/image/ImageCreateViewModel.kt
@@ -1,0 +1,18 @@
+package com.project.spire.ui.create.image
+
+import android.net.Uri
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class ImageCreateViewModel: ViewModel() {
+    private val _originImageUri = MutableLiveData<Uri>()
+    val originImageUri: LiveData<Uri>
+        get() = _originImageUri
+
+    fun setOriginImageUri(uri: Uri) {
+        _originImageUri.value = uri
+    }
+
+
+}

--- a/frontend/app/src/main/java/com/project/spire/ui/create/image/ImageEditActivity.kt
+++ b/frontend/app/src/main/java/com/project/spire/ui/create/image/ImageEditActivity.kt
@@ -2,21 +2,19 @@ package com.project.spire.ui.create.image
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.view.ViewGroup
 import android.widget.ImageView
-import androidx.constraintlayout.widget.ConstraintLayout
 import com.example.spire.R
-import android.content.Intent
-import android.util.Log
-import android.view.MotionEvent
-import android.view.ScaleGestureDetector
+import android.net.Uri
 import android.widget.Button
 import android.widget.EditText
-import android.widget.FrameLayout
 import android.widget.ImageButton
-import com.google.android.material.appbar.AppBarLayout
+import com.example.spire.databinding.ActivityImageEditBinding
+import androidx.activity.viewModels
 
 class ImageEditActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityImageEditBinding
+    private val viewModel: ImageCreateViewModel by viewModels()
 
     private lateinit var mImageView: ImageView
     private lateinit var mCanvasView: SpireCanvasView
@@ -29,12 +27,22 @@ class ImageEditActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         supportActionBar?.hide()
-        setContentView(R.layout.activity_image_edit)
 
-        mImageView = findViewById(R.id.editing_image)
-        mCanvasView = findViewById(R.id.spire_canvas_view)
+        binding = ActivityImageEditBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        editBtn = findViewById(R.id.edit_button)
+        val uri = Uri.parse(intent.getStringExtra("imageUri"))
+        viewModel.setOriginImageUri(uri)
+        mImageView = binding.editingImage
+        viewModel.originImageUri.observe(this) {
+            if (it != null) {
+                mImageView.setImageURI(it)
+            }
+        }
+
+        mCanvasView = binding.spireCanvasView
+
+        editBtn = binding.editButton
         editBtn.setOnClickListener {
             if (mCanvasView.isPenMode){
                 mCanvasView.isPenMode = false
@@ -47,7 +55,7 @@ class ImageEditActivity : AppCompatActivity() {
             }
         }
 
-        eraseBtn = findViewById(R.id.erase_button)
+        eraseBtn = binding.eraseButton
         eraseBtn.setOnClickListener {
             if (mCanvasView.isEraseMode){
                 mCanvasView.isEraseMode = false
@@ -60,15 +68,15 @@ class ImageEditActivity : AppCompatActivity() {
             }
         }
 
-        resetBtn = findViewById(R.id.reset_button)
+        resetBtn = binding.resetButton
         resetBtn.setOnClickListener {
             mCanvasView.clearCanvas()
             editBtn.setImageResource(R.drawable.ic_img_edit)
             eraseBtn.setImageResource(R.drawable.ic_img_erase)
         }
 
-        promptSuggestBtn = findViewById(R.id.prompt_suggestion_button)
-        promptInput = findViewById(R.id.prompt_input)
+        promptSuggestBtn = binding.promptSuggestionButton
+        promptInput = binding.promptInput
         promptSuggestBtn.setOnClickListener {
             val currentText = promptInput.text.toString()
             if (currentText == "") promptInput.setText(promptSuggestBtn.text)

--- a/frontend/app/src/main/java/com/project/spire/ui/create/image/ImageEditActivity.kt
+++ b/frontend/app/src/main/java/com/project/spire/ui/create/image/ImageEditActivity.kt
@@ -10,6 +10,7 @@ import android.widget.EditText
 import android.widget.ImageButton
 import com.example.spire.databinding.ActivityImageEditBinding
 import androidx.activity.viewModels
+import androidx.lifecycle.Observer
 
 class ImageEditActivity : AppCompatActivity() {
 
@@ -23,6 +24,7 @@ class ImageEditActivity : AppCompatActivity() {
     private lateinit var resetBtn: ImageButton
     private lateinit var promptSuggestBtn: Button
     private lateinit var promptInput: EditText
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -41,36 +43,38 @@ class ImageEditActivity : AppCompatActivity() {
         }
 
         mCanvasView = binding.spireCanvasView
+        mCanvasView.initViewModel(viewModel)
 
         editBtn = binding.editButton
-        editBtn.setOnClickListener {
-            if (mCanvasView.isPenMode){
-                mCanvasView.isPenMode = false
-                editBtn.setImageResource(R.drawable.ic_img_edit)
+        editBtn.setOnClickListener { viewModel.changePenMode() }
+        val penModeObserver = Observer<Boolean> { isPenMode ->
+            if (isPenMode) {
+                editBtn.setImageResource(R.drawable.ic_img_edit_selected)
             }
             else {
-                mCanvasView.penMode()
-                editBtn.setImageResource(R.drawable.ic_img_edit_selected)
-                eraseBtn.setImageResource(R.drawable.ic_img_erase)
+                editBtn.setImageResource(R.drawable.ic_img_edit)
             }
         }
+        viewModel.isPenMode.observe(this, penModeObserver)
 
         eraseBtn = binding.eraseButton
-        eraseBtn.setOnClickListener {
-            if (mCanvasView.isEraseMode){
-                mCanvasView.isEraseMode = false
-                eraseBtn.setImageResource(R.drawable.ic_img_erase)
+        eraseBtn.setOnClickListener { viewModel.changeEraseMode() }
+        val eraseModeObserver = Observer<Boolean> { isEraseMode ->
+            if (isEraseMode) {
+                eraseBtn.setImageResource(R.drawable.ic_img_erase_selected)
             }
             else {
-                mCanvasView.eraseMode()
-                eraseBtn.setImageResource(R.drawable.ic_img_erase_selected)
-                editBtn.setImageResource(R.drawable.ic_img_edit)
+                eraseBtn.setImageResource(R.drawable.ic_img_erase)
             }
         }
+        viewModel.isEraseMode.observe(this, eraseModeObserver)
+
+        val isDrawingObserver = Observer<Boolean> { mCanvasView.invalidate() }
+        viewModel.isDrawing.observe(this, isDrawingObserver)
 
         resetBtn = binding.resetButton
         resetBtn.setOnClickListener {
-            mCanvasView.clearCanvas()
+            viewModel.clearCanvas()
             editBtn.setImageResource(R.drawable.ic_img_edit)
             eraseBtn.setImageResource(R.drawable.ic_img_erase)
         }

--- a/frontend/app/src/main/java/com/project/spire/ui/create/image/PaintOptions.kt
+++ b/frontend/app/src/main/java/com/project/spire/ui/create/image/PaintOptions.kt
@@ -1,0 +1,7 @@
+package com.project.spire.ui.create.image
+
+import android.graphics.PorterDuffXfermode
+import java.io.Serializable
+
+data class PaintOptions(var strokeWidth: Float, var xfermode: PorterDuffXfermode?) :
+    Serializable

--- a/frontend/app/src/main/java/com/project/spire/ui/create/image/SpireCanvasView.kt
+++ b/frontend/app/src/main/java/com/project/spire/ui/create/image/SpireCanvasView.kt
@@ -18,43 +18,29 @@ import java.io.Serializable
 
 
 
-data class PaintOptions(var color: Int, var strokeWidth: Float, var xfermode: PorterDuffXfermode?) :
-    Serializable
-
 class SpireCanvasView(internal var context: Context, attrs: AttributeSet?) : View(context, attrs) {
 
     private val COLOR_BLUE = ContextCompat.getColor(context, R.color.blue_500)
-    private val COLOR_GRAY = ContextCompat.getColor(context, R.color.grey_300)
-    private val STROKE_PEN = 20f
-    private val STROKE_ERASER = 50f
-    private val MODE_CLEAR = PorterDuffXfermode(PorterDuff.Mode.CLEAR) // clears when overlapped
-    // drawing canvas
+    private lateinit var viewModel: ImageCreateViewModel
 
-    private var paths = LinkedHashMap<Path, PaintOptions>()
-    private var paintOptions = PaintOptions(COLOR_BLUE, STROKE_PEN, null)
-    private var currentX = 0f
-    private var currentY = 0f
-    private var startX = 0f
-    private var startY = 0f
+    fun initViewModel(viewModel: ImageCreateViewModel) {
+        this.viewModel = viewModel
+        // TODO: viewmodel을 이런 식으로 불러와도 되나..
+    }
 
-    var isEraseMode = false
-    var isPenMode = true
-    private var mbitmap: Bitmap? = null
-    private var mCanvas: Canvas? = null
-    private var mPath: Path = Path()
     private var mPaint: Paint = Paint()
 
     init {
         mPaint.isAntiAlias = true
         mPaint.style = Paint.Style.STROKE
         mPaint.strokeJoin = Paint.Join.ROUND
+        mPaint.color = COLOR_BLUE
     }
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
 
-        for ((path, options) in paths) {
-            mPaint.color = options.color
+        for ((path, options) in viewModel.paths) {
             mPaint.xfermode = options.xfermode
             mPaint.strokeWidth = options.strokeWidth
             if (options.xfermode != null) {
@@ -62,90 +48,24 @@ class SpireCanvasView(internal var context: Context, attrs: AttributeSet?) : Vie
                 // xfermode doesn't works with hardware acceleration
             }
             canvas.drawPath(path, mPaint)
-
         }
-        mPaint.color = paintOptions.color
-        mPaint.xfermode = paintOptions.xfermode
-        mPaint.strokeWidth = paintOptions.strokeWidth
-        if (isEraseMode) {
+        mPaint.xfermode = viewModel.paintOptions.xfermode
+        mPaint.strokeWidth = viewModel.paintOptions.strokeWidth
+        if (viewModel.isEraseMode.value!!) {
             setLayerType(LAYER_TYPE_HARDWARE, null)
-        } else {
-            mPaint.color = paintOptions.color
         }
-        canvas.drawPath(mPath, mPaint)
+       canvas.drawPath(viewModel.mPath, mPaint)
     }
-
+/*
     override fun onSizeChanged(w: Int, h: Int, oldw:Int, oldh: Int) {
         super.onSizeChanged(w, h, oldw, oldh)
         mbitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
         mCanvas = Canvas(mbitmap!!)
     }
-
-    fun clearCanvas() {
-        mPath.reset()
-        paths = LinkedHashMap()
-        isEraseMode = false
-        isPenMode = false
-        invalidate()
-    }
-
-    fun eraseMode() {
-        isEraseMode = true
-        isPenMode = false
-        paintOptions.color = COLOR_GRAY
-        paintOptions.strokeWidth = STROKE_ERASER
-        paintOptions.xfermode = MODE_CLEAR
-
-    }
-
-    fun penMode() {
-        isEraseMode = false
-        isPenMode = true
-        paintOptions.color = COLOR_BLUE
-        paintOptions.strokeWidth = STROKE_PEN
-        paintOptions.xfermode = null
-    }
+*/
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
-        if (!isPenMode and !isEraseMode) return true;
-        // don't need to track path is pen and eraser are both disabled
-
-        val y = event.y
-        val x = event.x
-        if (event.pointerCount == 1) { // don't track on multi-touch
-            when(event.action) {
-                MotionEvent.ACTION_DOWN -> {
-                    startX = x
-                    startY = y
-                    mPath.reset()
-                    mPath.moveTo(x, y)
-                    currentX = x
-                    currentY = y
-                    invalidate()
-                }
-                MotionEvent.ACTION_MOVE -> {
-                    mPath.quadTo(currentX, currentY, (x + currentX) / 2, (y + currentY) / 2)
-                    currentX = x
-                    currentY = y
-                    invalidate()
-                }
-                MotionEvent.ACTION_UP -> {
-                    mPath.lineTo(currentX, currentY)
-
-                    // draw a dot on click
-                    if (startX == currentX && startY == currentY) {
-                        mPath.lineTo(currentX, currentY + 2)
-                        mPath.lineTo(currentX + 1, currentY + 2)
-                        mPath.lineTo(currentX + 1, currentY)
-                    }
-
-                    paths[mPath] = paintOptions
-                    mPath = Path()
-                    paintOptions = PaintOptions(paintOptions.color, paintOptions.strokeWidth, paintOptions.xfermode)
-                    invalidate()
-                }
-            }
-        }
+        viewModel.processCanvasMotionEvent(event)
         return true
     }
 }

--- a/frontend/app/src/main/java/com/project/spire/ui/create/image/SpireCanvasView.kt
+++ b/frontend/app/src/main/java/com/project/spire/ui/create/image/SpireCanvasView.kt
@@ -1,22 +1,13 @@
 package com.project.spire.ui.create.image
 
 import android.content.Context
-import android.graphics.Bitmap
 import android.graphics.Canvas
-import android.graphics.Color
 import android.graphics.Paint
-import android.graphics.Path
-import android.graphics.PorterDuff
-import android.graphics.PorterDuffXfermode
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
 import androidx.core.content.ContextCompat
 import com.example.spire.R
-
-import java.io.Serializable
-
-
 
 class SpireCanvasView(internal var context: Context, attrs: AttributeSet?) : View(context, attrs) {
 


### PR DESCRIPTION
### PR Title: Image Select

#### PR Description:

- MainActivity의 Floating Button에서 PhotoPicker를 사용해 Image를 select하고, intent를 통해 image edit activity로 넘기는 기능을 구현하였습니다.
- Image Edit View의 logic을 ViewModel로 이동하였습니다.

##### Changes Included:
- [x] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation
##### Screenshots (if UI changes were made):

##### Notes for Reviewer:
touch 경로가 저장되는 실제 data는 mPath인데, 이를 ViewModel에 LiveData 형태로 저장하면 화면 갱신에 delay가 발생하여 대신 boolean variable을 하나 만들어 이를 observe하도록 하였습니다.

---
#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
expected.
- [ ] Code review comments have been addressed or clarified.

---