### PR TITLE
[merge] feat/follow-info -> dev/backend

### DIFF
--- a/backend/app/api/routers/user.py
+++ b/backend/app/api/routers/user.py
@@ -190,7 +190,7 @@ async def reject_follow(
     "/{user_id}/follow_info",
     summary="Get user follow info",
     description="Get user follow info",
-    dependencies=[Depends(PermissionDependency([AllowAll]))],
+    dependencies=[Depends(PermissionDependency([IsAuthenticated]))],
     response_model=GetFollowInfoResponse,
 )
 async def get_follow_info(
@@ -202,7 +202,6 @@ async def get_follow_info(
         user_id=user_id, current_user_id=req.user.id
     )
     return follow_info
-
 
 @user_router.get(
     "/{user_id}/followers",

--- a/backend/app/api/routers/user.py
+++ b/backend/app/api/routers/user.py
@@ -186,6 +186,24 @@ async def reject_follow(
     return {"message": f"Rejected user {user_id} follow"}
 
 @user_router.get(
+    "/{user_id}/follow_info",
+    summary="Get user follow info",
+    description="Get user follow info",
+    dependencies=[Depends(PermissionDependency([AllowAll]))],
+    # response_model=GetUsersResponse,
+)
+async def get_follow_info(
+    req: Request,
+    user_id: UUID4
+):
+    user_svc = UserService()
+    follow_info =  await user_svc.get_follow_info(
+        user_id=user_id, current_user_id=req.user.id
+    )
+    return follow_info
+
+
+@user_router.get(
     "/{user_id}/followers",
     summary="Get user followers",
     description="Get user followers",

--- a/backend/app/api/routers/user.py
+++ b/backend/app/api/routers/user.py
@@ -15,7 +15,8 @@ from app.schemas.user import (
     UserRead,
     UserUpdate,
     GetUsersResponse,
-    UserSearchResponse
+    UserSearchResponse, 
+    GetFollowInfoResponse
 )
 from app.session import get_db_transactional_session
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -190,7 +191,7 @@ async def reject_follow(
     summary="Get user follow info",
     description="Get user follow info",
     dependencies=[Depends(PermissionDependency([AllowAll]))],
-    # response_model=GetUsersResponse,
+    response_model=GetFollowInfoResponse,
 )
 async def get_follow_info(
     req: Request,

--- a/backend/app/core/exceptions/user.py
+++ b/backend/app/core/exceptions/user.py
@@ -28,6 +28,11 @@ class FollowMyselfException(CustomException):
     error_code = "FOLLOW__MYSELF"
     message = "follow myself"
 
+class FollowRequestAlreadyExistsException(CustomException):
+    code = 400
+    error_code = "FOLLOW__REQUEST_ALREADY_EXISTS"
+    message = "follow request already exists"
+
 class FollowAlreadyExistsException(CustomException):
     code = 400
     error_code = "FOLLOW__ALREADY_EXISTS"

--- a/backend/app/repository/user.py
+++ b/backend/app/repository/user.py
@@ -103,6 +103,18 @@ async def get_followers(user_id: UUID4, limit: int, offset: int, session: AsyncS
     return follower_list
 
 @Transactional()
+async def get_is_my_follower(user_id: UUID4, current_user_id: UUID4, session: AsyncSession):
+    stmt = select(func.count(Follow.id)).where(Follow.following_user_id == user_id, Follow.followed_user_id == current_user_id, Follow.accept_status == 1)
+    res = await session.execute(stmt)
+    return res.scalar_one()
+
+@Transactional()
+async def get_is_my_following(user_id: UUID4, current_user_id: UUID4, session: AsyncSession):
+    stmt = select(func.count(Follow.id)).where(Follow.followed_user_id == user_id, Follow.following_user_id == current_user_id,  Follow.accept_status == 1)
+    res = await session.execute(stmt)
+    return res.scalar_one()
+
+@Transactional()
 async def count_followings(user_id: UUID4, session: AsyncSession):
     stmt = select(func.count(Follow.id)).where(Follow.following_user_id == user_id, Follow.accept_status == 1)
     res = await session.execute(stmt)

--- a/backend/app/repository/user.py
+++ b/backend/app/repository/user.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import with_expression, selectinload, contains_eager
 from app.models.user import User, Follow
 from sqlalchemy.exc import IntegrityError, NoResultFound
 from sqlalchemy.orm import load_only
-from app.core.exceptions.user import UserNotFoundException, FollowAlreadyExistsException
+from app.core.exceptions.user import UserNotFoundException, FollowRequestAlreadyExistsException, FollowAlreadyExistsException
 
 
 @Transactional()
@@ -51,7 +51,10 @@ async def create_follow(following_user_id: UUID4, followed_user_id: UUID4, sessi
         session.add(follow)
 
     else:
-        raise FollowAlreadyExistsException()
+        if follow.accept_status == 0:
+            raise FollowRequestAlreadyExistsException()
+        else 
+            raise FollowAlreadyExistsException()
     
     await session.commit()
 

--- a/backend/app/repository/user.py
+++ b/backend/app/repository/user.py
@@ -53,7 +53,7 @@ async def create_follow(following_user_id: UUID4, followed_user_id: UUID4, sessi
     else:
         if follow.accept_status == 0:
             raise FollowRequestAlreadyExistsException()
-        else 
+        else:
             raise FollowAlreadyExistsException()
     
     await session.commit()
@@ -82,12 +82,22 @@ async def delete_follow(following_user_id: UUID4, followed_user_id: UUID4, sessi
 
 @Transactional()
 async def count_followers(user_id: UUID4, session: AsyncSession):
+    try:
+        await get_user_by_user_id(user_id, session=session)
+    except NoResultFound as e:
+        raise UserNotFoundException from e
+    
     stmt = select(func.count(Follow.id)).where(Follow.followed_user_id == user_id, Follow.accept_status == 1)
     res = await session.execute(stmt)
     return res.scalar_one()
 
 @Transactional()
 async def get_followers(user_id: UUID4, limit: int, offset: int, session: AsyncSession):
+    try:
+        await get_user_by_user_id(user_id, session=session)
+    except NoResultFound as e:
+        raise UserNotFoundException from e
+    
     stmt = (
         select(Follow)
         .where(Follow.followed_user_id == user_id, Follow.accept_status == 1)
@@ -119,12 +129,22 @@ async def get_is_my_following(user_id: UUID4, current_user_id: UUID4, session: A
 
 @Transactional()
 async def count_followings(user_id: UUID4, session: AsyncSession):
+    try:
+        await get_user_by_user_id(user_id, session=session)
+    except NoResultFound as e:
+        raise UserNotFoundException from e
+    
     stmt = select(func.count(Follow.id)).where(Follow.following_user_id == user_id, Follow.accept_status == 1)
     res = await session.execute(stmt)
     return res.scalar_one()
 
 @Transactional()
 async def get_followings(user_id: UUID4, limit: int, offset: int, session: AsyncSession):
+    try:
+        await get_user_by_user_id(user_id, session=session)
+    except NoResultFound as e:
+        raise UserNotFoundException from e
+    
     stmt = (
         select(Follow)
         .where(Follow.following_user_id == user_id, Follow.accept_status == 1)

--- a/backend/app/repository/user.py
+++ b/backend/app/repository/user.py
@@ -104,15 +104,15 @@ async def get_followers(user_id: UUID4, limit: int, offset: int, session: AsyncS
 
 @Transactional()
 async def get_is_my_follower(user_id: UUID4, current_user_id: UUID4, session: AsyncSession):
-    stmt = select(func.count(Follow.id)).where(Follow.following_user_id == user_id, Follow.followed_user_id == current_user_id, Follow.accept_status == 1)
+    stmt = select(Follow).where(Follow.following_user_id == user_id, Follow.followed_user_id == current_user_id)
     res = await session.execute(stmt)
-    return res.scalar_one()
+    return res.scalar_one_or_none()
 
 @Transactional()
 async def get_is_my_following(user_id: UUID4, current_user_id: UUID4, session: AsyncSession):
-    stmt = select(func.count(Follow.id)).where(Follow.followed_user_id == user_id, Follow.following_user_id == current_user_id,  Follow.accept_status == 1)
+    stmt = select(Follow).where(Follow.followed_user_id == user_id, Follow.following_user_id == current_user_id)
     res = await session.execute(stmt)
-    return res.scalar_one()
+    return res.scalar_one_or_none()
 
 @Transactional()
 async def count_followings(user_id: UUID4, session: AsyncSession):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -61,6 +61,12 @@ class FollowBase(BaseModel):
     followed_user_id: UUID4 = Field(..., description="Followed User Id")
     accept_status: int = Field(..., description="Follow Accept Status")
 
+class GetFollowInfoResponse(BaseModel):
+    follower_cnt: int = Field(..., description="Number of Followers")
+    following_cnt: UUID4 = Field(..., description="Number of Followings")
+    is_follower: bool = Field(..., description="Is My Follower")
+    is_following: bool = Field(..., description="Is My Following")
+
 class GetUsersResponse(BaseModel):
     total: int
     items: list[UserRead]

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -63,7 +63,7 @@ class FollowBase(BaseModel):
 
 class GetFollowInfoResponse(BaseModel):
     follower_cnt: int = Field(..., description="Number of Followers")
-    following_cnt: UUID4 = Field(..., description="Number of Followings")
+    following_cnt: int = Field(..., description="Number of Followings")
     is_follower: bool = Field(..., description="Is My Follower")
     is_following: bool = Field(..., description="Is My Following")
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -59,13 +59,13 @@ class CheckUserInfoResponse(BaseModel):
 class FollowBase(BaseModel):
     following_user_id: UUID4 = Field(..., description="Following User Id")
     followed_user_id: UUID4 = Field(..., description="Followed User Id")
-    accept_status: int = Field(..., description="Follow Accept Status")
+    accept_status: int = Field(..., description="Follow Accept Status, 0 : Requested, 1 : Accepted")
 
 class GetFollowInfoResponse(BaseModel):
     follower_cnt: int = Field(..., description="Number of Followers")
     following_cnt: int = Field(..., description="Number of Followings")
-    is_follower: bool = Field(..., description="Is My Follower")
-    is_following: bool = Field(..., description="Is My Following")
+    follower_status: int = Field(..., description="Follower Status, -1 : Not Follower, 0 : Requested, 1 : Accepted")
+    following_status: int = Field(..., description="Following Status, -1 : Not Following, 0 : Requested, 1 : Accepted")
 
 class GetUsersResponse(BaseModel):
     total: int

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -87,7 +87,7 @@ class UserService:
     @Transactional()
     async def get_follow_info(self, user_id: UUID4, current_user_id: UUID4, session: AsyncSession):
         try:
-            follower_cnt, folllowing_cnt, is_follower, is_following = await asyncio.gather(
+            follower_cnt, folllowing_cnt, follower_obj, following_obj = await asyncio.gather(
                 user.count_followers(user_id),
                 user.count_followings(user_id),
                 user.get_is_my_follower(user_id, current_user_id),
@@ -96,8 +96,18 @@ class UserService:
 
         except NoResultFound as e:
             raise NotFoundException("Follow not found") from e
+        
+        if follower_obj is None:
+            follower_status = -1
+        else:
+            follower_status = follower_obj.accept_status
 
-        return {"follower_cnt":follower_cnt, "following_cnt":folllowing_cnt, "is_follower":is_follower > 0,"is_following":is_following > 0}
+        if following_obj is None:
+            following_status = -1
+        else:
+            following_status = following_obj.accept_status
+
+        return {"follower_cnt":follower_cnt, "following_cnt":folllowing_cnt, "follower_status": follower_status, "following_status":following_status}
 
     @Transactional()
     async def get_followers(self, user_id: UUID4, limit: int, offset: int, session: AsyncSession):

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -70,7 +70,7 @@ class UserService:
             raise FollowNotFoundException from e
     
     @Transactional()
-    async def delete_follow(self, following_user_id: UUID4, followed_user_id: UUID4, accept_status: int, session: AsyncSession) -> Follow:
+    async def delete_follow(self, following_user_id: UUID4, followed_user_id: UUID4, accept_status: int, session: AsyncSession):
         try:
             follow_obj = await self.get_follow_by_user_ids(following_user_id, followed_user_id)
         except NoResultFound as e:

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -85,6 +85,21 @@ class UserService:
             raise FollowNotFoundException from e
 
     @Transactional()
+    async def get_follow_info(self, user_id: UUID4, current_user_id: UUID4, session: AsyncSession):
+        try:
+            follower_cnt, folllowing_cnt, is_follower, is_following = await asyncio.gather(
+                user.count_followers(user_id),
+                user.count_followings(user_id),
+                user.get_is_my_follower(user_id, current_user_id),
+                user.get_is_my_following(user_id, current_user_id)
+            )
+
+        except NoResultFound as e:
+            raise NotFoundException("Follow not found") from e
+
+        return {"follower_cnt":follower_cnt, "following_cnt":folllowing_cnt, "is_follower":is_follower > 0,"is_following":is_following > 0}
+
+    @Transactional()
     async def get_followers(self, user_id: UUID4, limit: int, offset: int, session: AsyncSession):
         try:
             total, users = await asyncio.gather(


### PR DESCRIPTION
### PR Title: Get basic follow info
#### Related Issue(s):
#55
#### PR Description:
- 특정 유저의 팔로워 수, 팔로잉 수, 본인 유저에 대한 팔로워 및 팔로어 여부 확인
- 추가적으로 UI 구현 시 필요한 팔로워 및 팔로잉 요청 상태 정보 추가 (-1: 요청 자체가 존재하지 않음, 0: 요청 중, 1: 요청 수락)

##### Changes Included:
- [x] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation

##### Notes for Reviewer:
- 존재하지 않는 유저에 대한 검색에 대해서 exception을 일으키지는 않습니다. (팔로우 요청 시에만 발생시킵니다)
- 본인이 본인에 대해 검색할 경우, is_follower와 is_following은 무시하면 됩니다. 따로 본인의 follow 정보를 불러오는 api를 따로 팔까하다가 너무 번거로워질 것 같아서 일단은 하나로 합쳤습니다.
- Get follow-info의 permission을 일단은 AllowAll이 아닌 IsAuthenticated로 설정했습니다. 팔로잉 및 팔로워 여부 확인을 위해 본인 유저 정보가 필수로 넘겨져야 해서요.

---
#### Reviewer Checklist:
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as
expected.
- [ ] Code review comments have been addressed or clarified.

---
